### PR TITLE
Drag compat

### DIFF
--- a/src/SchemaService.ts
+++ b/src/SchemaService.ts
@@ -1,0 +1,613 @@
+import { createHash } from "crypto";
+
+import * as vscode from "vscode";
+
+import { AuthenticationProvider } from "./SnowplowConsole";
+
+type IgluSchema = {
+  $schema?: "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#";
+  self: {
+    vendor: string;
+    name: string;
+    format: string;
+    version: string;
+  };
+  [key: string]: unknown;
+};
+
+type DataStructureResource = {
+  organizationId: string;
+  hash: string;
+  vendor: string;
+  name: string;
+  format: string;
+  description?: string;
+  meta: {
+    schemaType?: "event" | "entity";
+  };
+  deployments: {
+    version: string;
+    patchLevel: number;
+    contentHash: string;
+    env: string;
+  }[];
+};
+
+type WorkspaceDescriptor = {
+  kind: "workspace";
+  id: string;
+  name: string;
+  uri: vscode.Uri;
+};
+type StaticDescriptor = {
+  kind: "static";
+  id: string;
+  name: string;
+  baseUrl: string;
+  manifest: string;
+};
+type ConsoleDescriptor = {
+  kind: "organization";
+  id: string;
+  name: string;
+  organizationId: string;
+};
+
+export type RegistryDescriptor =
+  | WorkspaceDescriptor
+  | StaticDescriptor
+  | ConsoleDescriptor;
+
+export type SchemaDescriptor = {
+  schema?: IgluSchema;
+  igluUri: IgluUri;
+  registry: RegistryDescriptor;
+  hash: string;
+  uri: vscode.Uri;
+  env: "LOCAL" | "DEV" | "PROD";
+  schemaType?: "event" | "entity";
+};
+
+type SelectorProp =
+  | ((_: unknown) => boolean)
+  | string
+  | boolean
+  | number
+  | null
+  | Selector;
+export interface Selector extends Record<string, SelectorProp> {}
+
+const igluCentral = {
+  kind: "static",
+  id: "http://iglucentral.com/schemas",
+  name: "Iglu Central",
+  baseUrl: "http://iglucentral.com/schemas",
+  manifest: "",
+} as const;
+
+class IgluUri {
+  constructor(
+    public readonly vendor: string,
+    public readonly name: string,
+    public readonly format: string,
+    public readonly version: string
+  ) {}
+
+  public static parse(uri: string) {
+    const [schema, path, ...rest] = uri.split(":");
+
+    if (schema !== "iglu" || rest.length)
+      throw new Error("Invalid Iglu URI", {
+        cause: { uri, schema, path, rest },
+      });
+
+    const parts = path.split("/");
+
+    if (parts.length !== 4)
+      throw new Error("Invalid path in Iglu URI", {
+        cause: { uri, path, parts },
+      });
+
+    const [vendor, name, format, version] = parts;
+
+    return new IgluUri(vendor, name, format, version);
+  }
+
+  public static from({
+    vendor,
+    name,
+    format = "jsonschema",
+    version = "1-0-0",
+  }: {
+    vendor: string;
+    name: string;
+    format?: string;
+    version?: string;
+  }) {
+    return new IgluUri(vendor, name, format, version);
+  }
+
+  public toString(): string {
+    return `iglu:${this.vendor}/${this.name}/${this.format}/${this.version}`;
+  }
+
+  public hash(registry: string): string {
+    const sha256 = createHash("sha256");
+    sha256.update([registry, this.vendor, this.name, this.format].join("-"));
+    const hash = sha256.digest("hex");
+    return hash;
+  }
+}
+
+export class SchemaService implements vscode.Disposable {
+  private _dispose: vscode.Disposable[];
+
+  private staticRegistries: StaticDescriptor[];
+  private consoleRegistries: ConsoleDescriptor[];
+  private workspaceRegistries: WorkspaceDescriptor[];
+
+  private staticSchemas: SchemaDescriptor[];
+  private consoleSchemas: SchemaDescriptor[];
+  private workspaceSchemas: SchemaDescriptor[];
+
+  private markRegistriesDiscovered?: () => void;
+  private markSchemasDiscovered?: () => void;
+
+  public discovered: Promise<void>;
+
+  constructor(
+    private readonly provider: AuthenticationProvider,
+    public readonly uriNamespace: string
+  ) {
+    this.staticRegistries = [];
+    this.consoleRegistries = [];
+    this.workspaceRegistries = [];
+
+    this.staticSchemas = [];
+    this.consoleSchemas = [];
+    this.workspaceSchemas = [];
+
+    this._dispose = [];
+
+    this.discovered = Promise.all([
+      new Promise<void>((r) => (this.markRegistriesDiscovered = r)),
+      new Promise<void>((r) => (this.markSchemasDiscovered = r)),
+    ]).then();
+  }
+
+  public dispose(): void {
+    vscode.Disposable.from(...this._dispose).dispose();
+  }
+
+  public registries(): readonly RegistryDescriptor[] {
+    return ([] as RegistryDescriptor[]).concat(
+      this.workspaceRegistries,
+      this.consoleRegistries,
+      this.staticRegistries
+    );
+  }
+
+  public watchForRegistryChanges(): void {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      "**/*/jsonschema/*-*-*"
+    );
+
+    const handler = () => this.findLocalSchemas();
+
+    this._dispose.push(
+      watcher.onDidChange(handler),
+      watcher.onDidCreate(handler),
+      watcher.onDidDelete(handler),
+      watcher,
+      vscode.workspace.onDidChangeWorkspaceFolders(() =>
+        this.findLocalRegistries()
+      ),
+      this.provider.onDidChangeSessions(() => {
+        this.findConsoleRegistries();
+        this.findConsoleSchemas();
+      })
+    );
+  }
+
+  public async discover(): Promise<void> {
+    let ready = false;
+
+    return Promise.race([
+      this.discovered.then(() => {
+        ready = true;
+      }),
+      new Promise<void>((resolve, reject) =>
+        setTimeout(
+          () =>
+            ready
+              ? reject()
+              : resolve(this.findRegistries().then(() => this.findSchemas())),
+          1000
+        )
+      ),
+    ]);
+  }
+
+  public async findRegistries(): Promise<void> {
+    return Promise.all([
+      this.findConsoleRegistries(),
+      this.findLocalRegistries(),
+      this.findStaticRegistries(),
+    ]).then(() => this.markRegistriesDiscovered!());
+  }
+
+  public async findSchemas(): Promise<void> {
+    return Promise.all([
+      this.findConsoleSchemas(),
+      this.findLocalSchemas(),
+      this.findStaticSchemas(),
+    ]).then(() => this.markSchemasDiscovered!());
+  }
+
+  public async findStaticRegistries(): Promise<void> {
+    this.staticRegistries = [igluCentral];
+  }
+
+  public async findConsoleRegistries(): Promise<void> {
+    const sessions = await this.provider.getSessions();
+    this.consoleRegistries = sessions.map(({ id, account: { label } }) => ({
+      kind: "organization",
+      id,
+      name: label,
+      organizationId: id,
+    }));
+    if (!this.consoleRegistries.length) {
+      const session = await vscode.authentication.getSession(
+        AuthenticationProvider.providerId,
+        []
+      );
+      if (session)
+        this.consoleRegistries = [
+          {
+            kind: "organization",
+            id: session.id,
+            organizationId: session.id,
+            name: session.account.label,
+          },
+        ];
+    }
+  }
+
+  public async findLocalRegistries(): Promise<void> {
+    const schemaFiles = await vscode.workspace.findFiles(
+      "**/*/jsonschema/*-*-*"
+    );
+
+    const workspaceFolders = vscode.workspace.workspaceFolders || [
+      {
+        name: "No Active Folder/Workspace",
+        index: 0,
+        uri: vscode.Uri.parse("file:/"),
+      },
+    ];
+
+    this.workspaceRegistries = workspaceFolders
+      .filter((wsf) =>
+        schemaFiles.some((sf) => sf.toString().startsWith(wsf.uri.toString()))
+      )
+      .map((ws) => ({
+        kind: "workspace",
+        id: ws.name,
+        name: ws.name,
+        uri: ws.uri,
+      }));
+  }
+
+  private isSchema(data: unknown): data is IgluSchema {
+    if (typeof data === "object" && data && "self" in data) {
+      const hasSelf = data as Record<"self", unknown>;
+      if (typeof hasSelf["self"] === "object" && hasSelf["self"]) {
+        const self = hasSelf["self"] as Record<string, unknown>;
+
+        if (typeof self["vendor"] !== "string") return false;
+        if (typeof self["name"] !== "string") return false;
+        if (typeof self["format"] !== "string") return false;
+        if (typeof self["version"] !== "string") return false;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public async findLocalSchemas(): Promise<void> {
+    const schemaFiles = await vscode.workspace.findFiles(
+      "**/*/jsonschema/*-*-*"
+    );
+
+    const fileContents = new Map<vscode.Uri, Thenable<string>>();
+
+    const filesByWorkspace = this.workspaceRegistries.map((ws) =>
+      schemaFiles.filter((sf) => sf.toString().startsWith(ws.uri.toString()))
+    );
+
+    filesByWorkspace.flat().forEach((uri) => {
+      if (!fileContents.has(uri)) {
+        fileContents.set(
+          uri,
+          vscode.workspace.fs
+            .readFile(uri)
+            .then((bytes) => Buffer.from(bytes).toString("utf-8"))
+        );
+      }
+    });
+
+    const schemasByWorkspace = await Promise.all(
+      filesByWorkspace.map(async (uris) =>
+        Promise.allSettled(
+          uris.map(async (uri) => {
+            const buffer = fileContents.get(uri);
+            if (!buffer)
+              throw new Error("No file found for URI", { cause: { uri } });
+            const json = JSON.parse(await buffer);
+            if (this.isSchema(json)) return json;
+            throw new Error("File is JSON but doesn't appear to be a schema", {
+              cause: { uri },
+            });
+          })
+        )
+      )
+    );
+
+    this.workspaceSchemas = schemasByWorkspace.flatMap((schemaResults, i) =>
+      schemaResults.flatMap((result, j): SchemaDescriptor[] => {
+        if (result.status === "rejected") return [];
+
+        const registry = this.workspaceRegistries[i];
+
+        const schema = result.value;
+        const igluUri = IgluUri.from(schema["self"]);
+
+        return [
+          {
+            igluUri,
+            registry,
+            schema,
+            hash: igluUri.hash(registry.id),
+            uri: filesByWorkspace[i][j],
+            env: "LOCAL",
+          },
+        ];
+      })
+    );
+  }
+
+  public async findConsoleSchemas(): Promise<void> {
+    this.consoleSchemas = (
+      await Promise.allSettled(
+        this.consoleRegistries.map(async (registry) => {
+          const schemas: DataStructureResource[] =
+            await this.provider.consoleApiRequest(
+              "/data-structures/v1",
+              registry.organizationId
+            );
+
+          return schemas.flatMap((ds) =>
+            ds.deployments.flatMap((dep) => {
+              const igluUri = IgluUri.from({ ...ds, ...dep });
+
+              console.assert(
+                ds.hash === igluUri.hash(registry.organizationId),
+                "Schema hash mismatch",
+                ds.hash,
+                igluUri.hash(registry.organizationId),
+                ds,
+                igluUri
+              );
+
+              const consoleUri = vscode.Uri.from({
+                scheme: this.uriNamespace,
+                authority: registry.organizationId,
+                path: [
+                  "",
+                  igluUri.hash(registry.organizationId),
+                  igluUri.format,
+                  igluUri.version,
+                ].join("/"),
+                query: dep.env ? `?env=${dep.env}` : undefined,
+              });
+
+              return {
+                igluUri,
+                registry,
+                hash: igluUri.hash(registry.id),
+                env: dep.env as "DEV" | "PROD",
+                uri: consoleUri,
+                schemaType: ds.meta.schemaType,
+              };
+            })
+          );
+        })
+      )
+    ).flatMap((result) => (result.status === "rejected" ? [] : result.value));
+  }
+
+  public async findStaticSchemas(): Promise<void> {
+    this.staticSchemas = (
+      await Promise.allSettled(
+        this.staticRegistries.map(async (registry) => {
+          const baseUrl = vscode.Uri.parse(registry.baseUrl);
+          const manifestUri = vscode.Uri.joinPath(baseUrl, registry.manifest);
+
+          const manifest: string[] = await fetch(manifestUri.toString()).then(
+            (r) => (r.ok ? r.json() : Promise.reject(r))
+          );
+
+          return manifest.map((uri) => {
+            const igluUri = IgluUri.parse(uri);
+            const staticUri = vscode.Uri.joinPath(
+              baseUrl.with({ scheme: this.uriNamespace }),
+              igluUri.vendor,
+              igluUri.name,
+              igluUri.format,
+              igluUri.version
+            );
+
+            return {
+              igluUri,
+              registry,
+              hash: igluUri.hash(registry.id),
+              env: "PROD" as const,
+              uri: staticUri,
+            };
+          });
+        })
+      )
+    ).flatMap((result) => (result.status === "rejected" ? [] : result.value));
+  }
+
+  private matchSelector(schema: SchemaDescriptor, selector: Selector): boolean {
+    return this.innerMatch(true, schema, selector);
+  }
+
+  private innerMatch(
+    matching: boolean,
+    subject: Record<string, unknown>,
+    selector: Selector
+  ): boolean {
+    for (const p in selector) {
+      const candidate = selector[p];
+      if (p in subject || typeof candidate === "function") {
+        const inner = subject[p];
+        if (typeof candidate === "function") {
+          matching = matching && candidate(inner);
+        } else if (candidate === null) {
+          matching = matching && inner === null;
+        } else if (p === "igluUri" && typeof candidate === "string") {
+          matching = matching && candidate === "" + inner;
+        } else if (
+          typeof candidate === "object" &&
+          typeof inner === "object" &&
+          inner
+        ) {
+          matching =
+            matching &&
+            this.innerMatch(
+              matching,
+              inner as Record<string, unknown>,
+              candidate
+            );
+        } else {
+          matching = matching && inner === candidate;
+        }
+      } else return false;
+    }
+
+    return matching;
+  }
+
+  public getSchemas(selector?: Selector): SchemaDescriptor[] {
+    if (selector) {
+      const filter = (s: SchemaDescriptor) => this.matchSelector(s, selector);
+      return [
+        ...this.workspaceSchemas.filter(filter),
+        ...this.consoleSchemas.filter(filter),
+        ...this.staticSchemas.filter(filter),
+      ];
+    } else
+      return [
+        ...this.workspaceSchemas,
+        ...this.consoleSchemas,
+        ...this.staticSchemas,
+      ];
+  }
+
+  public querySchemas<T>(
+    query: (previousResult: T, schema: SchemaDescriptor) => T,
+    initial: T,
+    selector?: Selector
+  ): T {
+    if (selector) {
+      const filter = (s: SchemaDescriptor) => this.matchSelector(s, selector);
+      initial = this.workspaceSchemas.filter(filter).reduce(query, initial);
+      initial = this.consoleSchemas.filter(filter).reduce(query, initial);
+      initial = this.staticSchemas.filter(filter).reduce(query, initial);
+    } else {
+      initial = this.workspaceSchemas.reduce(query, initial);
+      initial = this.consoleSchemas.reduce(query, initial);
+      initial = this.staticSchemas.reduce(query, initial);
+    }
+
+    return initial;
+  }
+
+  public async fetchSchema(descriptor: SchemaDescriptor): Promise<IgluSchema> {
+    if (descriptor.schema) return descriptor.schema;
+
+    let result: IgluSchema | undefined = undefined;
+
+    switch (descriptor.registry.kind) {
+      case "organization":
+        const [_, schemaHash, format, version] = descriptor.uri.path.split("/");
+        const env = descriptor.uri.query || "";
+
+        const schema = await this.provider.consoleApiRequest(
+          `/data-structures/v1/${schemaHash}/versions/${version}${env}`,
+          descriptor.registry.organizationId
+        );
+
+        if (this.isSchema(schema)) result = schema;
+        break;
+      case "static":
+        const urls = [
+          descriptor.uri.with({ scheme: "http" }),
+          descriptor.uri.with({ scheme: "https" }),
+        ];
+        result = await Promise.any(
+          urls.map((url) =>
+            fetch(url.toString())
+              .then((resp) =>
+                resp.ok
+                  ? resp.json()
+                  : Promise.reject(
+                      new Error("bad response", { cause: { resp } })
+                    )
+              )
+              .then((maybe) =>
+                this.isSchema(maybe)
+                  ? maybe
+                  : Promise.reject(
+                      new Error("invalid schema", { cause: { payload: maybe } })
+                    )
+              )
+          )
+        );
+        break;
+      case "workspace":
+        result = await vscode.workspace.fs
+          .readFile(descriptor.uri)
+          .then((bytes) => JSON.parse(Buffer.from(bytes).toString("utf-8")))
+          .then((maybe) =>
+            this.isSchema(maybe)
+              ? maybe
+              : Promise.reject(
+                  new Error("invalid schema file", {
+                    cause: { uri: descriptor.uri },
+                  })
+                )
+          );
+    }
+
+    if (result) {
+      descriptor.schema = result;
+      return result;
+    } else {
+      throw new Error("could not fetch schema", { cause: descriptor });
+    }
+  }
+
+  public async resolve(
+    request: SchemaDescriptor | IgluUri | string | Selector
+  ): Promise<IgluSchema> {
+    if (typeof request === "string") request = IgluUri.parse(request);
+    if (request instanceof IgluUri) request = { igluUri: request.toString() };
+
+    return Promise.any(
+      this.getSchemas(request as Selector).map((desc) => this.fetchSchema(desc))
+    );
+  }
+}

--- a/src/TreeViews/SchemasProvider.ts
+++ b/src/TreeViews/SchemasProvider.ts
@@ -1,57 +1,26 @@
-import { createHash } from "crypto";
-
 import * as vscode from "vscode";
-import fetch from "isomorphic-fetch";
+
+import { TextDocumentContentProvider } from "../SnowplowConsole";
 
 import {
-  AuthenticationProvider,
-  TextDocumentContentProvider,
-} from "../SnowplowConsole";
-
-type DataStructureResource = {
-  organizationId: string;
-  hash: string;
-  vendor: string;
-  name: string;
-  format: string;
-  description?: string;
-  meta: {
-    schemaType?: "event" | "entity";
-  };
-  deployments: {
-    version: string;
-    patchLevel: number;
-    contentHash: string;
-    env: string;
-  }[];
-};
+  SchemaService,
+  RegistryDescriptor,
+  SchemaDescriptor,
+  Selector,
+} from "../SchemaService";
 
 type SchemaProviderElement =
-  | { kind: "workspace"; repoName: string; uri: vscode.Uri }
-  | { kind: "static"; baseUrl: string; manifest: string; repoName: string }
-  | { kind: "organization"; organizationId: string; organization: string }
-  | { kind: "vendor"; organizationId: string; vendor: string }
-  | { kind: "name"; organizationId: string; vendor: string; name: string }
+  | RegistryDescriptor
+  | { kind: "vendor"; registry: RegistryDescriptor; vendor: string }
+  | { kind: "name"; registry: RegistryDescriptor; vendor: string; name: string }
   | {
       kind: "format";
-      organizationId: string;
+      registry: RegistryDescriptor;
       vendor: string;
       name: string;
       format: string;
-      hash: string;
     }
-  | {
-      kind: "version";
-      organizationId: string;
-      vendor: string;
-      name: string;
-      format: string;
-      hash: string;
-      version: string;
-      contentHash: string;
-      env: string;
-      schemaType: DataStructureResource["meta"]["schemaType"];
-    };
+  | ({ kind: "version" } & SchemaDescriptor);
 
 export class SchemasDragAndDropController
   implements vscode.TreeDragAndDropController<string>
@@ -81,46 +50,13 @@ export class SchemasDragAndDropController
   }
 }
 
-export class SchemasProvider
-  implements vscode.TreeDataProvider<string>, vscode.Disposable
-{
-  private static readonly _schemas: Map<string, DataStructureResource> =
-    new Map();
-
+export class SchemasProvider implements vscode.TreeDataProvider<string> {
   private static readonly elementCache: Map<string, SchemaProviderElement> =
     new Map();
 
   private _onDidChangeTreeData = new vscode.EventEmitter<string | void>();
-  private _disposable: vscode.Disposable;
 
-  constructor(
-    private readonly provider: AuthenticationProvider,
-    private readonly textDocProvider: TextDocumentContentProvider
-  ) {
-    const watcher = vscode.workspace.createFileSystemWatcher(
-      "**/*/jsonschema/*-*-*"
-    );
-    const keyUpdate = (prefix: string) => () =>
-      Array.from(SchemasProvider.elementCache.keys())
-        .filter((k) => k.startsWith(prefix))
-        .forEach((k) => this._onDidChangeTreeData.fire(k));
-
-    watcher.onDidChange(keyUpdate("workspace."));
-    watcher.onDidCreate(keyUpdate("workspace."));
-    watcher.onDidDelete(keyUpdate("workspace."));
-
-    this._disposable = vscode.Disposable.from(
-      vscode.workspace.onDidChangeWorkspaceFolders(() =>
-        this._onDidChangeTreeData.fire()
-      ),
-      this.provider.onDidChangeSessions(() => this._onDidChangeTreeData.fire()),
-      watcher
-    );
-  }
-
-  public dispose() {
-    this._disposable.dispose();
-  }
+  constructor(private readonly schemaService: SchemaService) {}
 
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
@@ -132,21 +68,17 @@ export class SchemasProvider
     let id: string;
     switch (element.kind) {
       case "workspace":
-        id = [element.kind, element.repoName].join(".");
-        break;
       case "static":
-        id = [element.kind, element.baseUrl].join(".");
-        break;
       case "organization":
-        id = [element.kind, element.organizationId].join(".");
+        id = [element.kind, element.id].join(".");
         break;
       case "vendor":
-        id = [element.kind, element.organizationId, element.vendor].join(".");
+        id = [element.kind, element.registry.id, element.vendor].join(".");
         break;
       case "name":
         id = [
           element.kind,
-          element.organizationId,
+          element.registry.id,
           element.vendor,
           element.name,
         ].join(".");
@@ -154,7 +86,7 @@ export class SchemasProvider
       case "format":
         id = [
           element.kind,
-          element.organizationId,
+          element.registry.id,
           element.vendor,
           element.name,
           element.format,
@@ -163,9 +95,9 @@ export class SchemasProvider
       case "version":
         id = [
           element.kind,
-          element.organizationId,
-          element.contentHash || [element.vendor, element.name].join("."),
-          element.version,
+          element.registry.id,
+          element.igluUri.hash(element.registry.id),
+          element.igluUri.version,
           element.env,
         ].join(".");
         break;
@@ -190,16 +122,16 @@ export class SchemasProvider
     switch (element.kind) {
       case "workspace":
         return buildTI({
-          label: element.repoName,
+          label: element.name,
         });
       case "static":
         return buildTI({
-          label: element.repoName,
+          label: element.name,
           description: element.baseUrl,
         });
       case "organization":
         return buildTI({
-          label: element.organization,
+          label: element.name,
           description: element.organizationId,
         });
       case "vendor":
@@ -217,64 +149,19 @@ export class SchemasProvider
           label: element.format,
         });
       case "version":
-        const igluUri = `iglu:${element.vendor}/${element.name}/${element.format}/${element.version}`;
-        let command: vscode.Command;
-        let resourceUri: vscode.Uri | undefined = undefined;
-
-        if (element.env === "LOCAL") {
-          resourceUri = vscode.Uri.parse(element.contentHash);
-          command = {
-            title: "View Iglu Schema",
-            command: "vscode.open",
-            arguments: [element.contentHash, { preview: true }, igluUri],
-          };
-        } else if (element.contentHash) {
-          const consoleUri = vscode.Uri.from({
-            scheme: TextDocumentContentProvider.scheme,
-            authority: element.organizationId,
-            path: ["", element.hash, element.format, element.version].join("/"),
-            query: element.env ? `?env=${element.env}` : undefined,
-          });
-
-          resourceUri = consoleUri;
-
-          command = {
-            title: "View Iglu Schema",
-            command: "vscode.open",
-            arguments: [consoleUri, { preview: true }, igluUri],
-          };
-        } else {
-          const staticUri = vscode.Uri.from({
-            scheme: TextDocumentContentProvider.scheme,
-            authority: "",
-            path: [
-              "",
-              element.vendor,
-              element.name,
-              element.format,
-              element.version,
-            ].join("/"),
-            fragment: element.organizationId,
-          });
-
-          resourceUri = staticUri;
-
-          command = {
-            title: "View Iglu Schema",
-            command: "vscode.open",
-            arguments: [staticUri, { preview: true }, igluUri],
-          };
-        }
-
-        this.textDocProvider.addToResolver(resourceUri, { self: element });
+        const { env, igluUri, schemaType, uri } = element;
 
         return buildTI({
-          label: element.version,
+          label: igluUri.version,
           collapsibleState: None,
-          description: `${element.schemaType || "schema"} | ${element.env}`,
-          tooltip: igluUri,
-          resourceUri,
-          command,
+          description: `${schemaType || "schema"} | ${env}`,
+          tooltip: igluUri.toString(),
+          resourceUri: uri,
+          command: {
+            title: "View Iglu Schema",
+            command: "vscode.open",
+            arguments: [uri, { preview: true }, igluUri.toString()],
+          },
         });
     }
   }
@@ -288,64 +175,14 @@ export class SchemasProvider
     }
   }
 
-  private async getRootChildren(): Promise<SchemaProviderElement[]> {
-    const igluCentral: SchemaProviderElement = {
-      kind: "static",
-      repoName: "Iglu Central",
-      baseUrl: "http://iglucentral.com/schemas",
-      manifest: "",
-    };
-
-    const schemaFiles = await vscode.workspace.findFiles(
-      "**/*/jsonschema/*-*-*"
-    );
-    const workspaceFolders = vscode.workspace.workspaceFolders || [
-      {
-        name: "No Active Folder/Workspace",
-        index: 0,
-        uri: vscode.Uri.parse("file:/"),
-      },
-    ];
-
-    const workspaces: SchemaProviderElement[] = workspaceFolders
-      .filter((wsf) =>
-        schemaFiles.some((sf) => sf.toString().startsWith(wsf.uri.toString()))
-      )
-      .map((ws) => ({
-        kind: "workspace",
-        repoName: ws.name,
-        uri: ws.uri,
-      }));
-
-    const sessions = await this.provider.getSessions();
-    if (!sessions.length) {
-      const session = await vscode.authentication.getSession(
-        AuthenticationProvider.providerId,
-        []
-      );
-      if (session)
-        return [
-          ...workspaces,
-          {
-            kind: "organization",
-            organizationId: session.id,
-            organization: session.account.label,
-          },
-          igluCentral,
-        ];
-      else return [...workspaces, igluCentral];
+  private async getRootChildren(): Promise<readonly SchemaProviderElement[]> {
+    const registries = this.schemaService.registries();
+    if (registries.length) {
+      return registries;
+    } else {
+      await this.schemaService.findRegistries();
+      return this.schemaService.registries();
     }
-
-    return workspaces.concat(
-      sessions.map(
-        ({ id, account: { label } }): SchemaProviderElement => ({
-          kind: "organization",
-          organizationId: id,
-          organization: label,
-        })
-      ),
-      [igluCentral]
-    );
   }
 
   private async getNodeChildren(
@@ -353,15 +190,17 @@ export class SchemasProvider
   ): Promise<SchemaProviderElement[]> {
     switch (element.kind) {
       case "workspace":
-        return this.getWorkspaceNodeChildren(element);
-      case "static":
-        return this.getStaticNodeChildren(element);
+        await this.schemaService.findLocalSchemas();
+        return this.getUniqueNextChildren(element);
       case "organization":
-        return this.getOrganizationNodeChildren(element);
+        await this.schemaService.findConsoleSchemas();
+        return this.getUniqueNextChildren(element);
+      case "static":
+        await this.schemaService.findStaticSchemas();
+        return this.getUniqueNextChildren(element);
       case "vendor":
-        return this.getVendorNodeChildren(element);
       case "name":
-        return this.getNameNodeChildren(element);
+        return this.getUniqueNextChildren(element);
       case "format":
         return this.getFormatNodeChildren(element);
       case "version":
@@ -369,196 +208,90 @@ export class SchemasProvider
     }
   }
 
-  private async getWorkspaceNodeChildren(
-    element: Extract<SchemaProviderElement, { kind: "workspace" }>
-  ): Promise<SchemaProviderElement[]> {
-    const schemaFiles = await vscode.workspace.findFiles(
-      "**/*/jsonschema/*-*-*"
-    );
-    const urisForFolder = schemaFiles.filter((sf) =>
-      sf.toString().startsWith(element.uri.toString())
-    );
+  private async getUniqueNextChildren(
+    element: Exclude<SchemaProviderElement, { kind: "version" | "format" }>
+  ): Promise<
+    Exclude<SchemaProviderElement, RegistryDescriptor | { kind: "version" }>[]
+  > {
+    const nextKind = (
+      {
+        organization: "vendor",
+        static: "vendor",
+        workspace: "vendor",
+        vendor: "name",
+        name: "format",
+      } as const
+    )[element.kind];
 
-    const contents = await Promise.all(
-      urisForFolder.map((fsUri) =>
-        vscode.workspace.fs.readFile(fsUri).then((bytes) => ({
-          fsUri,
-          contents: Buffer.from(bytes).toString("utf-8"),
-        }))
-      )
-    );
+    const registry = "registry" in element ? element.registry : element;
 
-    const localVendors: Set<string> = new Set();
+    const selector: Selector = {
+      registry: { kind: registry.kind, id: registry.id },
+    };
 
-    contents.forEach(({ fsUri, contents }) => {
-      let jsonContents;
-      try {
-        jsonContents = JSON.parse(contents);
-        if (
-          typeof jsonContents !== "object" ||
-          !jsonContents ||
-          !("self" in jsonContents)
-        )
-          return;
-      } catch {
-        return;
-      }
-
-      const { vendor, name, format, version } = jsonContents["self"];
-
-      const sha256 = createHash("sha256");
-      sha256.update([element.repoName, vendor, name].join("-"));
-      const hash = sha256.digest("hex");
-
-      const ds: DataStructureResource = {
-        organizationId: element.repoName,
-        vendor,
-        name,
-        format,
-        hash,
-        meta: {},
-        deployments: [],
+    if (element.kind === "vendor") {
+      selector["igluUri"] = {
+        vendor: element.vendor,
       };
-
-      ds.deployments.push({
-        version,
-        patchLevel: 1,
-        env: "LOCAL",
-        contentHash: fsUri.toString(),
-      });
-
-      localVendors.add(vendor);
-      SchemasProvider._schemas.set(hash, ds);
-    });
-
-    return Array.from(localVendors.values())
-      .sort()
-      .map((vendor) => ({
-        kind: "vendor",
-        organizationId: element.repoName,
-        vendor,
-      }));
-  }
-
-  private async getStaticNodeChildren(
-    element: Extract<SchemaProviderElement, { kind: "static" }>
-  ): Promise<SchemaProviderElement[]> {
-    const uri = vscode.Uri.joinPath(
-      vscode.Uri.parse(element.baseUrl),
-      element.manifest
-    );
-    const manifest: string[] = await fetch(uri.toString()).then((r) =>
-      r.ok ? r.json() : Promise.reject(r)
-    );
-
-    const manifestVendors = new Set<string>();
-
-    manifest.forEach((igluUri) => {
-      const [vendor, name, format, version] = igluUri
-        .replace("iglu:", "")
-        .split("/");
-
-      const sha256 = createHash("sha256");
-      sha256.update([element.baseUrl, vendor, name].join("-"));
-      const hash = sha256.digest("hex");
-
-      const ds = SchemasProvider._schemas.get(hash) || {
-        organizationId: element.baseUrl,
-        vendor,
-        name,
-        format,
-        hash,
-        meta: {},
-        deployments: [],
+    } else if (element.kind === "name") {
+      selector["igluUri"] = {
+        vendor: element.vendor,
+        name: element.name,
       };
-
-      ds.deployments.push({
-        version,
-        patchLevel: 1,
-        env: "PROD",
-        contentHash: "",
-      });
-
-      manifestVendors.add(vendor);
-      SchemasProvider._schemas.set(hash, ds);
-    });
-
-    return Array.from(manifestVendors.values())
-      .sort()
-      .map((vendor) => ({
-        kind: "vendor",
-        organizationId: element.baseUrl,
-        vendor,
-      }));
-  }
-
-  private async getOrganizationNodeChildren(
-    element: Extract<SchemaProviderElement, { kind: "organization" }>
-  ): Promise<SchemaProviderElement[]> {
-    const schemas: DataStructureResource[] =
-      await this.provider.consoleApiRequest(
-        "/data-structures/v1",
-        element.organizationId
-      );
-
-    const vendors = new Set<string>();
-    for (const ds of schemas) {
-      SchemasProvider._schemas.set(ds.hash, ds);
-      vendors.add(ds.vendor);
     }
 
-    return Array.from(vendors.values())
+    const uniques: Set<string> = new Set();
+    this.schemaService.querySchemas(
+      (acc, schema) => {
+        acc.add(schema.igluUri[nextKind]);
+        return acc;
+      },
+      uniques,
+      selector
+    );
+
+    return Array.from(uniques.values())
       .sort()
-      .map((vendor) => ({
-        kind: "vendor",
-        organizationId: element.organizationId,
-        vendor,
-      }));
-  }
-
-  private async getVendorNodeChildren(
-    element: Extract<SchemaProviderElement, { kind: "vendor" }>
-  ): Promise<SchemaProviderElement[]> {
-    return Array.from(SchemasProvider._schemas.values())
-      .filter(
-        (ds) =>
-          ds.organizationId === element.organizationId &&
-          ds.vendor === element.vendor
-      )
-      .map((ds) => ({ kind: "name", ...ds }));
-  }
-
-  private async getNameNodeChildren(
-    element: Extract<SchemaProviderElement, { kind: "name" }>
-  ): Promise<SchemaProviderElement[]> {
-    return Array.from(SchemasProvider._schemas.values())
-      .filter(
-        (ds) =>
-          ds.organizationId === element.organizationId &&
-          ds.vendor === element.vendor &&
-          ds.name === element.name
-      )
-      .map((ds) => ({ kind: "format", ...ds }));
+      .map((unique) => {
+        if (nextKind === "name" && element.kind === "vendor") {
+          return {
+            kind: nextKind,
+            registry,
+            vendor: element.vendor,
+            name: unique,
+          };
+        } else if (nextKind === "format" && element.kind === "name") {
+          return {
+            kind: nextKind,
+            registry,
+            vendor: element.vendor,
+            name: element.name,
+            format: unique,
+          };
+        } else if (nextKind === "vendor") {
+          return { kind: nextKind, registry, vendor: unique };
+        } else return "unreachable" as never;
+      });
   }
 
   private async getFormatNodeChildren(
     element: Extract<SchemaProviderElement, { kind: "format" }>
   ): Promise<SchemaProviderElement[]> {
-    const ds = SchemasProvider._schemas.get(element.hash);
+    const schemas = this.schemaService.getSchemas({
+      registry: {
+        kind: element.registry.kind,
+        id: element.registry.id,
+      },
+      igluUri: {
+        vendor: element.vendor,
+        name: element.name,
+        format: element.format,
+      },
+    });
 
-    return ds
-      ? ds.deployments.map(({ env, contentHash, version }) => ({
-          kind: "version",
-          organizationId: ds.organizationId,
-          vendor: ds.vendor,
-          name: ds.name,
-          format: ds.format,
-          hash: ds.hash,
-          version,
-          env,
-          contentHash,
-          schemaType: ds.meta.schemaType,
-        }))
-      : [];
+    return schemas.map((schema) => ({
+      kind: "version",
+      ...schema,
+    }));
   }
 }


### PR DESCRIPTION
- Makes dragging and dropping schemas from the Schemas treeview work similar to files in the local file browser.
- Includes a large refactor to centralize the logic for fetching schemas into a `SchemaService` as we now need to know about all the found schemas not just in the tree but when the drag/drop happens.
- VS Code should now recognize iglu URIs in open files, and Ctrl clicking them should find the corresponding schema from the schema tree and open the schema definition.
- There is an odd error where, after clicking a schema from the treeview to view its definition, the drop events stop working and instead you just the the URI path added to your file. Not sure why this is but suspect a VS Code API issue at the moment.